### PR TITLE
Refactor metrics middleware

### DIFF
--- a/lib/thrift_server.rb
+++ b/lib/thrift_server.rb
@@ -9,6 +9,7 @@ require 'statsd-ruby'
 
 require_relative 'thrift_server/logging_middleware'
 require_relative 'thrift_server/metrics_middleware'
+require_relative 'thrift_server/rpc_metrics_middleware'
 require_relative 'thrift_server/error_tracking_middleware'
 require_relative 'thrift_server/honeybadger_error_tracker'
 
@@ -79,6 +80,7 @@ class ThriftServer
       stack = MiddlewareStack.new
       stack.use ErrorTrackingMiddleware, error_tracker
       stack.use MetricsMiddleware, statsd
+      stack.use RpcMetricsMiddleware, statsd
       stack.use LoggingMiddleware, logger
 
       yield stack if block_given?

--- a/lib/thrift_server/metrics_middleware.rb
+++ b/lib/thrift_server/metrics_middleware.rb
@@ -3,13 +3,17 @@ class ThriftServer
     include Concord.new(:app, :statsd)
 
     def call(rpc)
-      statsd.increment rpc.name
+      statsd.increment 'thrift.rpc.incoming'
 
-      statsd.time rpc.name do
+      response = statsd.time 'thrift.rpc.latency' do
         app.call rpc
       end
+
+      statsd.increment 'thrift.rpc.success'
+
+      response
     rescue => ex
-      statsd.increment 'errors'
+      statsd.increment 'thrift.rpc.error'
       raise ex
     end
   end

--- a/lib/thrift_server/rpc_metrics_middleware.rb
+++ b/lib/thrift_server/rpc_metrics_middleware.rb
@@ -1,0 +1,20 @@
+class ThriftServer
+  class RpcMetricsMiddleware
+    include Concord.new(:app, :statsd)
+
+    def call(rpc)
+      statsd.increment "thrift.#{rpc.name}.incoming"
+
+      response = statsd.time "thrift.#{rpc.name}.latency" do
+        app.call rpc
+      end
+
+      statsd.increment "thrift.#{rpc.name}.success"
+
+      response
+    rescue => ex
+      statsd.increment "thrift.#{rpc.name}.error"
+      raise ex
+    end
+  end
+end

--- a/test/rpc_metrics_middleware_test.rb
+++ b/test/rpc_metrics_middleware_test.rb
@@ -1,0 +1,42 @@
+require_relative 'test_helper'
+
+class RpcMetricsMiddlewareTest < MiniTest::Unit::TestCase
+  TestError = Class.new StandardError
+
+  attr_reader :rpc
+
+  def setup
+    @rpc = ThriftServer::RPC.new :foo, :bar
+  end
+
+  def test_happy_path_call
+    app = stub call: :result
+
+    statsd = mock
+    statsd.expects(:increment).with('thrift.foo.incoming')
+    statsd.expects(:increment).with('thrift.foo.success')
+    statsd.expects(:time).with('thrift.foo.latency').yields.returns(:response)
+
+    middleware = ThriftServer::RpcMetricsMiddleware.new(app, statsd)
+
+    response = middleware.call rpc
+
+    assert_equal :response, response
+  end
+
+  def test_rpc_raises_an_error
+    app = stub
+    app.stubs(:call).raises(TestError)
+
+    statsd = mock
+    statsd.expects(:increment).with('thrift.foo.incoming')
+    statsd.expects(:increment).with('thrift.foo.error')
+    statsd.expects(:time).with('thrift.foo.latency').yields.returns(:response)
+
+    middleware = ThriftServer::RpcMetricsMiddleware.new(app, statsd)
+
+    assert_raises TestError do
+      middleware.call rpc
+    end
+  end
+end


### PR DESCRIPTION
This commits breaks out the metrics into two different middleware. The
the default one has changed. By default, the following server level
metrics are tracked:

* count of successful RPC
* count of failed RPC
* timing of each RPC

A second middleware is introduced to track the same metrics for every
RPC. This middleware is opt-in.