### PR TITLE
Provide threaded & thread pool server factories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,19 +34,22 @@ test-lib: tmp/image
 	$(DOCKER_RUN) $(APP) bundle exec rake
 
 .PHONY: test-network
-test-network: tmp/image gen-rb/echo_service.rb
-	-@docker stop server > /dev/null 2>&1
-	-@docker rm -v server > /dev/null 2>&1
-	docker run -d --name server $(APP) ruby echo_server.rb
-	$(DOCKER_RUN) --link server:server $(APP) ruby echo_client.rb server 9090
+test-network: tmp/image gen-rb/echo_service.rb clean-containers
+	docker run -d --name threaded_server $(APP) ruby echo_server.rb --threaded
+	docker run -d --name thread_pool_server $(APP) ruby echo_server.rb --thread-pool
+	$(DOCKER_RUN) --link threaded_server:server $(APP) ruby echo_client.rb server 9090
+	$(DOCKER_RUN) --link thread_pool_server:server $(APP) ruby echo_client.rb server 9090
 
 .PHONY: test-ci
 test-ci: test-lib test-network
 
+.PHONY: clean-containers
+clean-containers:
+	-@docker stop thread_pool_server threaded_server > /dev/null 2>&1
+	-@docker rm -v thread_pool_server threaded_server > /dev/null 2>&1
+
 .PHONY: clean
-clean:
-	-docker stop server > /dev/null 2>&1
-	-docker rm -v server > /dev/null 2>&1
+clean: clean-containers
 	@mkdir -p tmp
 	@touch tmp/image
 	-cat tmp/image | xargs --no-run-if-empty docker rmi

--- a/echo_server.rb
+++ b/echo_server.rb
@@ -27,7 +27,14 @@ class Handler
   end
 end
 
-server = ThriftServer.build EchoService, Handler.new
-server.log Logger.new($stdout)
-
-server.start
+if ARGV.include?('--threaded')
+  server = ThriftServer.threaded EchoService, Handler.new
+  server.log Logger.new($stdout)
+  server.start
+elsif ARGV.include?('--thread-pool')
+  server = ThriftServer.thread_pool EchoService, Handler.new
+  server.log Logger.new($stdout)
+  server.start
+else
+  abort 'No server option given'
+end

--- a/lib/thrift_server/log_subscriber.rb
+++ b/lib/thrift_server/log_subscriber.rb
@@ -2,25 +2,7 @@ module ThriftServer
   class LogSubscriber
     include Concord.new(:logger)
 
-    def server_start(server)
-      logger.info :server do
-        "Started on port %d" % [ server.port ]
-      end
-
-      logger.info :server do
-        "-> Threads: %d" % [ server.threads ]
-      end
-
-      logger.info :server do
-        "-> Transport: %s" % [ server.transport ]
-      end
-
-      logger.info :server do
-        "-> Protocol: %s" % [ server.protocol ]
-      end
-    end
-
-    def server_thread_pool_change(meta)
+    def thread_pool_server_pool_change(meta)
       logger.debug :server do
         "Thread pool change: %+d" % [ meta.fetch(:delta) ]
       end

--- a/lib/thrift_server/server_metrics_subscriber.rb
+++ b/lib/thrift_server/server_metrics_subscriber.rb
@@ -3,15 +3,11 @@ module ThriftServer
     include Concord.new(:statsd)
 
     def server_connection_opened(*)
-      statsd.gauge 'server.pool.active', '+1'
+      statsd.gauge 'server.connection.active', '+1'
     end
 
     def server_connection_closed(*)
-      statsd.gauge 'server.pool.active', '-1'
-    end
-
-    def server_thread_pool_change(meta)
-      statsd.gauge('server.pool.size', '%+d' % [ meta.fetch(:delta) ])
+      statsd.gauge 'server.connection.active', '-1'
     end
 
     def rpc_incoming(rpc)

--- a/lib/thrift_server/threaded_server.rb
+++ b/lib/thrift_server/threaded_server.rb
@@ -1,0 +1,87 @@
+module ThriftServer
+  class ThreadedServer < Thrift::ThreadedServer
+    class LogSubscriber
+      include Concord.new(:logger)
+
+      def server_start(server)
+        logger.info :server do
+          "Started on port %d" % [ server.port ]
+        end
+
+        logger.info :server do
+          "-> Transport: %s" % [ server.transport ]
+        end
+
+        logger.info :server do
+          "-> Protocol: %s" % [ server.protocol ]
+        end
+      end
+    end
+
+    extend Forwardable
+
+    def_delegators :@processor, :use
+    def_delegators :@processor, :publisher, :publish, :subscribe
+
+    attr_accessor :port
+
+    def log(logger)
+      subscribe LogSubscriber.new(logger)
+      subscribe ThriftServer::LogSubscriber.new(logger)
+    end
+
+    def metrics(statsd)
+      subscribe ServerMetricsSubscriber.new(statsd)
+      subscribe RpcMetricsSubscriber.new(statsd)
+    end
+
+    def protocol
+      @protocol_factory
+    end
+
+    def transport
+      @transport_factory
+    end
+
+    def server_transport
+      @server_transport
+    end
+
+    def start(dry_run: false)
+      publish :server_start, self
+
+      serve unless dry_run
+    end
+
+    # NOTE: this is a copy of the upstream code with instrumentation added.
+    def serve
+      begin
+        @server_transport.listen
+        loop do
+          client = @server_transport.accept
+
+          remote_address = client.handle.remote_address
+          publish :server_connection_opened, remote_address
+
+          trans = @transport_factory.get_transport(client)
+          prot = @protocol_factory.get_protocol(trans)
+
+          Thread.new(prot, trans) do |p, t|
+            begin
+              loop do
+                @processor.process(p, p)
+              end
+            rescue Thrift::TransportException, Thrift::ProtocolException
+            ensure
+              publish :server_connection_closed, remote_address
+
+              t.close
+            end
+          end
+        end
+      ensure
+        @server_transport.close
+      end
+    end
+  end
+end

--- a/test/log_subscriber_test.rb
+++ b/test/log_subscriber_test.rb
@@ -3,38 +3,6 @@ require_relative 'test_helper'
 class LogSubscriberTest < MiniTest::Unit::TestCase
   attr_reader :logger, :subscriber, :rpc
 
-  # Make it easy to assert on a string line generated through the standard lib
-  # progname & block syntax. This class will automatically yield the block and
-  # concat it the mock receives a single line. This also ensures the block
-  # is always executed, making sure it's free of errors
-  class LogYielder
-    include Concord.new(:log)
-
-    def info(msg)
-      if msg && block_given?
-        log.info "#{msg} #{yield}"
-      else
-        log.info msg
-      end
-    end
-
-    def error(msg)
-      if msg && block_given?
-        log.error "#{msg} #{yield}"
-      else
-        log.error msg
-      end
-    end
-
-    def debug(msg)
-      if msg && block_given?
-        log.debug "#{msg} #{yield}"
-      else
-        log.debug msg
-      end
-    end
-  end
-
   def setup
     @logger = mock
     @subscriber = ThriftServer::LogSubscriber.new LogYielder.new(logger)
@@ -42,47 +10,20 @@ class LogSubscriberTest < MiniTest::Unit::TestCase
     @rpc = ThriftServer::RPC.new :foo, :bar
   end
 
-  def test_server_start
-    server = stub({
-      port: 9999,
-      threads: 30,
-      transport: 'StubTransport',
-      protocol: 'StubProtocol'
-    })
-
-    logger.expects(:info).with do |line|
-      line =~ /9999/
-    end
-
-    logger.expects(:info).with do |line|
-      line =~ /30/
-    end
-
-    logger.expects(:info).with do |line|
-      line =~ /StubTransport/
-    end
-
-    logger.expects(:info).with do |line|
-      line =~ /StubProtocol/
-    end
-
-    subscriber.server_start server
-  end
-
-  def test_server_thread_pool_change_with_positive_delta
+  def test_thread_pool_server_pool_change_with_positive_delta
     logger.expects(:debug).with do |line|
       line =~ /\+1/
     end
 
-    subscriber.server_thread_pool_change delta: 1
+    subscriber.thread_pool_server_pool_change delta: 1
   end
 
-  def test_server_thread_pool_change_with_negative_delta
+  def test_thread_pool_server_pool_change_with_negative_delta
     logger.expects(:debug).with do |line|
       line =~ /-1/
     end
 
-    subscriber.server_thread_pool_change delta: -1
+    subscriber.thread_pool_server_pool_change delta: -1
   end
 
   def test_server_connection_opened

--- a/test/server_metrics_subscriber_test.rb
+++ b/test/server_metrics_subscriber_test.rb
@@ -13,23 +13,13 @@ class ServerMetricsSubscriberTest < MiniTest::Unit::TestCase
   end
 
   def test_server_connection_opened
-    statsd.expects(:gauge).with('server.pool.active', '+1')
+    statsd.expects(:gauge).with('server.connection.active', '+1')
     subscriber.server_connection_opened :addr
   end
 
   def test_server_connection_closed
-    statsd.expects(:gauge).with('server.pool.active', '-1')
+    statsd.expects(:gauge).with('server.connection.active', '-1')
     subscriber.server_connection_closed :addr
-  end
-
-  def test_server_thread_pool_change_with_positive_delta
-    statsd.expects(:gauge).with('server.pool.size', '+1')
-    subscriber.server_thread_pool_change delta: 1
-  end
-
-  def test_server_thread_pool_change_with_negative_delta
-    statsd.expects(:gauge).with('server.pool.size', '-1')
-    subscriber.server_thread_pool_change delta: -1
   end
 
   def test_rpc_incoming

--- a/test/support/log_yielder.rb
+++ b/test/support/log_yielder.rb
@@ -1,0 +1,32 @@
+# Make it easy to assert on a string line generated through the standard lib
+# progname & block syntax. This class will automatically yield the block and
+# concat it the mock receives a single line. This also ensures the block
+# is always executed, making sure it's free of errors
+class LogYielder
+  include Concord.new(:log)
+
+  def info(msg)
+    if msg && block_given?
+      log.info "#{msg} #{yield}"
+    else
+      log.info msg
+    end
+  end
+
+  def error(msg)
+    if msg && block_given?
+      log.error "#{msg} #{yield}"
+    else
+      log.error msg
+    end
+  end
+
+  def debug(msg)
+    if msg && block_given?
+      log.debug "#{msg} #{yield}"
+    else
+      log.debug msg
+    end
+  end
+end
+

--- a/test/support/server_tests.rb
+++ b/test/support/server_tests.rb
@@ -1,0 +1,87 @@
+module ServerTests
+  def test_defaults_to_port_9090
+    server = build service, stub
+    assert_equal 9090, server.port
+  end
+
+  def test_accepts_port_options
+    server = build(service, stub, {
+      port: 5000
+    })
+
+    assert_equal 5000, server.port
+  end
+
+  def test_creates_server_with_framed_transport
+    server = build service, stub
+
+    assert_instance_of Thrift::FramedTransportFactory, server.transport
+  end
+
+  def test_uses_server_socket_transport
+    server = build service, stub
+
+    assert_instance_of Thrift::ServerSocket, server.server_transport
+  end
+
+  def test_creates_server_with_binary_protocol
+    server = build service, stub
+
+    assert_instance_of Thrift::BinaryProtocolFactory, server.protocol
+  end
+
+  def test_subscribers_receive_server_start
+    subscriber = mock
+    subscriber.expects(:server_start)
+
+    server = build(service, stub) do |server|
+      server.subscribe subscriber
+    end
+
+    server.start dry_run: true
+  end
+
+  def test_shortcut_method_for_attaching_log_subscriber
+    ThriftServer::LogSubscriber.expects(:new).with(:stdout).returns(:generic)
+
+    server = build(service, stub) do |server|
+      server.log :stdout
+    end
+
+    assert_includes server.publisher, :generic
+  end
+
+  def test_shortcut_method_for_attaching_metrics
+    ThriftServer::ServerMetricsSubscriber.expects(:new).with(:statsd).returns(:server)
+    ThriftServer::RpcMetricsSubscriber.expects(:new).with(:statsd).returns(:rpc)
+
+    server = build(service, stub) do |server|
+      server.metrics :statsd
+    end
+
+    assert_includes server.publisher, :server
+    assert_includes server.publisher, :rpc
+  end
+
+  def test_attaching_subscribers_to_server
+    server = build(service, stub) do |server|
+      server.subscribe :tester
+    end
+
+    assert_includes server.publisher, :tester
+  end
+
+  def test_adding_middleware_to_server
+    test_middleware = Class.new do
+      include Concord.new(:app)
+
+      def call(env)
+        app.call env
+      end
+    end
+
+    server = build(service, stub) do |server|
+      server.use test_middleware
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,9 @@ require 'logger-better'
 require 'minitest/autorun'
 require 'mocha/mini_test'
 
+require_relative 'support/server_tests'
+require_relative 'support/log_yielder'
+
 TestError = Class.new StandardError
 
 class FakeStatsd

--- a/test/thread_pool_server_test.rb
+++ b/test/thread_pool_server_test.rb
@@ -1,0 +1,101 @@
+require_relative 'test_helper'
+
+class ThreadPoolSeverTest < MiniTest::Unit::TestCase
+  include ServerTests
+
+  attr_reader :service
+
+  def setup
+    @service = TestService
+  end
+
+  def build(*args, &block)
+    ThriftServer.send :thread_pool, *args, &block
+  end
+
+  def test_returns_thread_pool_server
+    server = build service, stub
+
+    assert_kind_of Thrift::ThreadPoolServer, server
+  end
+
+  def test_defaults_to_25_threads
+    server = build service, stub
+
+    assert_equal 25, server.threads
+  end
+
+  def test_accepts_threads_option
+    server = build(service, stub, {
+      threads: 8
+    })
+
+    assert_equal 8, server.threads
+  end
+
+  def test_attaches_its_own_log_subscriber
+    ThriftServer::ThreadPoolServer::LogSubscriber.expects(:new).with(:stdout).returns(:custom)
+
+    server = build(service, stub) do |server|
+      server.log :stdout
+    end
+
+    assert_includes server.publisher, :custom
+  end
+
+  def test_start_up_logging
+    logger = mock
+    subscriber = ThriftServer::ThreadPoolServer::LogSubscriber.new LogYielder.new(logger)
+
+    server = stub({
+      port: 9999,
+      threads: 30,
+      transport: 'StubTransport',
+      protocol: 'StubProtocol'
+    })
+
+    logger.expects(:info).with do |line|
+      line =~ /9999/
+    end
+
+    logger.expects(:info).with do |line|
+      line =~ /30/
+    end
+
+    logger.expects(:info).with do |line|
+      line =~ /StubTransport/
+    end
+
+    logger.expects(:info).with do |line|
+      line =~ /StubProtocol/
+    end
+
+    subscriber.server_start server
+  end
+
+  def test_attaches_own_metrics_subcriber
+    ThriftServer::ThreadPoolServer::MetricsSubscriber.expects(:new).with(:statsd).returns(:custom)
+
+    server = build(service, stub) do |server|
+      server.metrics :statsd
+    end
+
+    assert_includes server.publisher, :custom
+  end
+
+  def test_thread_pool_server_pool_change_with_positive_delta
+    statsd = mock
+    subscriber = ThriftServer::ThreadPoolServer::MetricsSubscriber.new statsd
+
+    statsd.expects(:gauge).with('server.pool.size', '+1')
+    subscriber.thread_pool_server_pool_change delta: 1
+  end
+
+  def test_thread_pool_server_pool_change_with_negative_delta
+    statsd = mock
+    subscriber = ThriftServer::ThreadPoolServer::MetricsSubscriber.new statsd
+
+    statsd.expects(:gauge).with('server.pool.size', '-1')
+    subscriber.thread_pool_server_pool_change delta: -1
+  end
+end

--- a/test/threaded_server_test.rb
+++ b/test/threaded_server_test.rb
@@ -1,0 +1,56 @@
+require_relative 'test_helper'
+
+class ThreadedServerTest < MiniTest::Unit::TestCase
+  include ServerTests
+
+  attr_reader :service
+
+  def setup
+    @service = TestService
+  end
+
+  def build(*args, &block)
+    ThriftServer.send :threaded, *args, &block
+  end
+
+  def test_is_threaded_server
+    server = build service, stub
+
+    assert_kind_of Thrift::ThreadedServer, server
+  end
+
+  def test_attaches_its_own_log_subscriber
+    ThriftServer::ThreadedServer::LogSubscriber.expects(:new).with(:stdout).returns(:custom)
+
+    server = build(service, stub) do |server|
+      server.log :stdout
+    end
+
+    assert_includes server.publisher, :custom
+  end
+
+  def test_start_up_logging
+    logger = mock
+    subscriber = ThriftServer::ThreadedServer::LogSubscriber.new LogYielder.new(logger)
+
+    server = stub({
+      port: 9999,
+      transport: 'StubTransport',
+      protocol: 'StubProtocol'
+    })
+
+    logger.expects(:info).with do |line|
+      line =~ /9999/
+    end
+
+    logger.expects(:info).with do |line|
+      line =~ /StubTransport/
+    end
+
+    logger.expects(:info).with do |line|
+      line =~ /StubProtocol/
+    end
+
+    subscriber.server_start server
+  end
+end


### PR DESCRIPTION
Additions:

* ThriftServer.threaded returns a threaded server
* ThriftServer.thread_pool returns a pool based server

Changes:

* server.pool.active => server.connection.active

Removals:

* ThriftServer.build (use ThriftServer.thread_pool from this point on)