### PR TITLE
Log & Instrument error in server loops

### DIFF
--- a/lib/thrift_server/log_subscriber.rb
+++ b/lib/thrift_server/log_subscriber.rb
@@ -26,6 +26,18 @@ module ThriftServer
       end
     end
 
+    def server_internal_error(addr, ex)
+      logger.info :server do
+        "%s:%d => Error! %s" % [
+          addr.ip_address,
+          addr.ip_port,
+          ex.class.name
+        ]
+      end
+
+      logger.error ex
+    end
+
     def rpc_ok(rpc, response, meta)
       logger.info :processor do
         "%s => OK (%.2fms)" % [

--- a/lib/thrift_server/server_metrics_subscriber.rb
+++ b/lib/thrift_server/server_metrics_subscriber.rb
@@ -10,6 +10,10 @@ module ThriftServer
       statsd.gauge 'server.connection.active', '-1'
     end
 
+    def server_internal_error(_ex)
+      statsd.increment 'server.internal_error'
+    end
+
     def rpc_incoming(rpc)
       statsd.increment 'rpc.incoming'
     end

--- a/lib/thrift_server/thread_pool_server.rb
+++ b/lib/thrift_server/thread_pool_server.rb
@@ -94,8 +94,10 @@ module ThriftServer
                     @processor.process(prot, prot)
                   end
                 rescue Thrift::TransportException, Thrift::ProtocolException => e
-                  publish :server_connection_closed, remote_address
+                  publish :server_internal_error, remote_address, ex
                 ensure
+                  publish :server_connection_closed, remote_address
+
                   trans.close
                 end
               end

--- a/lib/thrift_server/threaded_server.rb
+++ b/lib/thrift_server/threaded_server.rb
@@ -71,7 +71,8 @@ module ThriftServer
               loop do
                 @processor.process(p, p)
               end
-            rescue Thrift::TransportException, Thrift::ProtocolException
+            rescue Thrift::TransportException, Thrift::ProtocolException => ex
+              publish :server_internal_error, remote_address, ex
             ensure
               publish :server_connection_closed, remote_address
 

--- a/test/log_subscriber_test.rb
+++ b/test/log_subscriber_test.rb
@@ -46,6 +46,22 @@ class LogSubscriberTest < MiniTest::Unit::TestCase
     subscriber.server_connection_closed addr
   end
 
+  def test_server_internal_error
+    error = Thrift::TransportException.new
+    addr = stub ip_address: 'stub_ip', ip_port: 823
+
+    logger.expects(:info).with do |line|
+      assert_includes line, addr.ip_address
+      assert_includes line, addr.ip_port.to_s
+      assert_match /Error/, line
+      assert_includes line, error.class.name
+    end
+
+    logger.expects(:error).with(error)
+
+    subscriber.server_internal_error addr, error
+  end
+
   def test_rpc_ok_logs_result_to_info
     logger.expects(:info).with do |line|
       assert_match /foo/, line, 'RPC name not printed'

--- a/test/server_metrics_subscriber_test.rb
+++ b/test/server_metrics_subscriber_test.rb
@@ -22,6 +22,11 @@ class ServerMetricsSubscriberTest < MiniTest::Unit::TestCase
     subscriber.server_connection_closed :addr
   end
 
+  def test_server_internal_error
+    statsd.expects(:increment).with('server.internal_error')
+    subscriber.server_internal_error Exception.new
+  end
+
   def test_rpc_incoming
     statsd.expects(:increment).with('rpc.incoming')
 


### PR DESCRIPTION
This commit provides visibility into previously silent errors in the
Threaded & Thread Pool servers threading loops.