### PR TITLE
Update ruby version 2.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.1
+FROM ruby:2.4
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/lib/thrift_server.rb
+++ b/lib/thrift_server.rb
@@ -59,6 +59,8 @@ module ThriftServer
 
     include Concord::Public.new(:stack, :publisher, :handler)
 
+    attr_reader :publisher, :handler, :stack
+
     def call(rpc)
       app.call rpc
     end

--- a/test/log_subscriber_test.rb
+++ b/test/log_subscriber_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class LogSubscriberTest < MiniTest::Unit::TestCase
+class LogSubscriberTest <  Minitest::Test
   attr_reader :logger, :subscriber, :rpc
 
   def setup

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class ProcessorTest < MiniTest::Unit::TestCase
+class ProcessorTest < Minitest::Test
   attr_reader :service
 
   def setup

--- a/test/rpc_metrics_subscriber_test.rb
+++ b/test/rpc_metrics_subscriber_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class RpcMetricsSubscriberTest < MiniTest::Unit::TestCase
+class RpcMetricsSubscriberTest < Minitest::Test
   TestError = Class.new StandardError
 
   attr_reader :subscriber, :rpc, :statsd

--- a/test/server_metrics_subscriber_test.rb
+++ b/test/server_metrics_subscriber_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class ServerMetricsSubscriberTest < MiniTest::Unit::TestCase
+class ServerMetricsSubscriberTest < Minitest::Test
   TestError = Class.new StandardError
 
   attr_reader :subscriber, :rpc, :statsd

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require 'stringio'
 require 'logger-better'
 
 require 'minitest/autorun'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 
 require_relative 'support/server_tests'
 require_relative 'support/log_yielder'

--- a/test/thread_pool_server_test.rb
+++ b/test/thread_pool_server_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class ThreadPoolSeverTest < MiniTest::Unit::TestCase
+class ThreadPoolSeverTest < Minitest::Test
   include ServerTests
 
   attr_reader :service

--- a/test/threaded_server_test.rb
+++ b/test/threaded_server_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class ThreadedServerTest < MiniTest::Unit::TestCase
+class ThreadedServerTest < Minitest::Test
   include ServerTests
 
   attr_reader :service

--- a/test/validation_middleware_test.rb
+++ b/test/validation_middleware_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class ValidationMiddlewareTest < MiniTest::Unit::TestCase
+class ValidationMiddlewareTest < Minitest::Test
   class StructResponse
     include ::Thrift::Struct
 

--- a/thrift_server.gemspec
+++ b/thrift_server.gemspec
@@ -24,9 +24,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thrift"
   spec.add_dependency "thrift-validator"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 1.17.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "logger-better"
   spec.add_development_dependency "benchmark-ips"
+  spec.add_development_dependency "minitest"
 end


### PR DESCRIPTION
Update ruby version to 2.4 and resolve dependencies.

Ruby version in Notification service was updated to 2.4, which also requires ruby version to be updated for thrift_ruby_server.
[Notification PR](https://github.com/Saltside/notification-service/pull/86)